### PR TITLE
#3 Handles Jobs Without Requirement of WaitGroup

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,14 +45,11 @@ The user can create a job like this:
 
 ```go
 job1 := func() {
-    defer wg.Done()
     fmt.Println("Hello from octopool!")
 }
 ```
 
 The job is just a function, which can hold anything in its body, like a function call, a print statement, etc.
-
-> Note: Remember to keep the job's initial line to `defer wg.Done()` as it would prevent other jobs to abruptly stop the current job's execution. **You should maintain a WaitGroup to prevent overriding execution of jobs. The example with a WaitGroup is given in the [Example](#example) section.**
 
 Once the job has been created, the user can call the octopus to handle the incoming job:
 
@@ -62,6 +59,8 @@ octo.HandleJob(job1, "normal-octojob")
 
 `octopool` lets the user to name jobs. This is not an required argument, but comes in handy while debugging.
 
+Lastly, the user calls `octo.Wait()`.  This call blocks continued execution until all jobs are finished.
+
 # Example
 
 ## Creating an octopus with an invalid capacity:
@@ -70,39 +69,33 @@ In this example, you will see:
 - How Octopool can prevent panics when the octopus is created with an invalid capacity
 - How to create jobs
 - How to let the octopus handle jobs
-- How to implement a WaitGroup to prevent overriding of jobs
+- How to let the octopus handle Wait
 
 ```go
 package main
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/burntcarrot/octopool"
 )
 
 func main() {
-	var wg sync.WaitGroup
 	octo := octopool.NewOctopus(0)
 
 	job1 := func() {
-		defer wg.Done()
 		fmt.Println("Hello from octopool!")
 	}
 
 	job2 := func() {
-		defer wg.Done()
 		fmt.Println("Hello user!")
 	}
 
 	for i := 0; i < 1; i++ {
-		wg.Add(1)
 		octo.HandleJob(job1, "normal-octojob")
-		wg.Add(1)
 		octo.HandleJob(job2, "greet-user")
-		wg.Wait()
 	}
+	octo.Wait()
 }
 ```
 
@@ -125,32 +118,26 @@ package main
 
 import (
 	"fmt"
-	"sync"
 
 	"github.com/burntcarrot/octopool"
 )
 
 func main() {
-	var wg sync.WaitGroup
 	octo := octopool.NewOctopus(10, 100)
 
 	job1 := func() {
-		defer wg.Done()
 		fmt.Println("Hello from octopool!")
 	}
 
 	job2 := func() {
-		defer wg.Done()
 		fmt.Println("Hello user!")
 	}
 
 	for i := 0; i < 1; i++ {
-		wg.Add(1)
 		octo.HandleJob(job1, "normal-octojob")
-		wg.Add(1)
 		octo.HandleJob(job2, "greet-user")
-		wg.Wait()
 	}
+	octo.Wait()
 }
 ```
 

--- a/benchmark_test.go
+++ b/benchmark_test.go
@@ -2,7 +2,6 @@ package octopool_test
 
 import (
 	"fmt"
-	"sync"
 	"testing"
 	"time"
 
@@ -12,21 +11,17 @@ import (
 func benchmarkOctopus(poolCapacity int, queueCapacity int, b *testing.B) {
 	pool := octopool.NewOctopus(poolCapacity, queueCapacity)
 
-	var wg sync.WaitGroup
-
 	job1 := func() {
-		defer wg.Done()
 		time.Sleep(100 * time.Millisecond)
 	}
 
 	for i := 0; i < b.N; i++ {
-		wg.Add(1)
 		err := pool.HandleJob(job1, "normal-octojob")
 		if err != nil {
 			fmt.Println(err.Error())
 		}
 	}
-	wg.Wait()
+	pool.Wait()
 }
 
 func Benchmark_Octopus_Pool10_Queue100(b *testing.B) {

--- a/octopus.go
+++ b/octopus.go
@@ -147,3 +147,9 @@ func (octo *Octopus) processNext() {
 		log.Println("assigned job:", job.name, "to a worker.")
 	}
 }
+
+// Waits on workers to finish the job
+func (octo *Octopus) Wait() {
+	log.Println("Waiting for jobs to finish....")
+	octo.workerPool.wg.Wait()
+}

--- a/octopus_test.go
+++ b/octopus_test.go
@@ -206,3 +206,29 @@ func TestOctopusAvailableWorkers(t *testing.T) {
 
 	assert.Equal(t, 3, testOctopus.AvailableWorkers())
 }
+
+func TestOctopusWait(t *testing.T) {
+	testOctopus := NewOctopus(5)
+
+	job1 := func() {
+		time.Sleep(1 * time.Second)
+	}
+
+	job2 := func() {
+		time.Sleep(2 * time.Second)
+	}
+
+	err := testOctopus.HandleJob(job1, "job 1")
+	if err != nil {
+		t.Errorf("Got error while handling job: %v", err)
+	}
+
+	err = testOctopus.HandleJob(job2, "job 2")
+	if err != nil {
+		t.Errorf("Got error while handling job: %v", err)
+	}
+
+	testOctopus.Wait()
+
+	assert.Equal(t, 5, testOctopus.AvailableWorkers())
+}

--- a/pool.go
+++ b/pool.go
@@ -28,13 +28,14 @@ const (
 )
 
 type pool struct {
-	status           state      // represents current state of the pool
-	capacity         int        // number of workers the pool can accommodate
-	availableWorkers sync.Pool  // pool of available workers
-	activeWorkers    int        // number of active workers
-	closePool        sync.Once  // closes pool and can be called only once
-	mu               sync.Mutex // mutex for locking
-	octopus          *Octopus   // provides an API to interact with the pool
+	status           state          // represents current state of the pool
+	capacity         int            // number of workers the pool can accommodate
+	availableWorkers sync.Pool      // pool of available workers
+	activeWorkers    int            // number of active workers
+	closePool        sync.Once      // closes pool and can be called only once
+	mu               sync.Mutex     // mutex for locking
+	octopus          *Octopus       // provides an API to interact with the pool
+	wg               sync.WaitGroup // used to wait for multiple goroutines to finish
 }
 
 // Basic helper functions:

--- a/worker.go
+++ b/worker.go
@@ -23,7 +23,9 @@ type worker struct {
 
 // Executes the job provided to the worker.
 func (w *worker) run() {
+	w.pool.wg.Add(1)
 	go func() {
+		defer w.pool.wg.Done()
 		defer func() {
 			// silently recover from error, do not panic
 			if r := recover(); r != nil {


### PR DESCRIPTION
Fixes #3 

My original idea to follow the [example](https://github.com/gammazero/workerpool#example) provided didn't quite work out how I intended....for some reason the execution dropped off by the time `pool.Wait()` was called.
So I thought of a more simpler approach....move the `WaitGroups` into the Worker Pool.

Would like some feedback.
If this is an acceptable approach, I can update the documentation.
